### PR TITLE
[Solves #2] add timeout for ClipWait

### DIFF
--- a/HorticraftPricer.ahk
+++ b/HorticraftPricer.ahk
@@ -440,7 +440,11 @@ valuedictionary[RAW_Jewel_Implicit_Cluster] := Jewel_Implicit_Cluster
 !w Up::
     clipboard := ""
     Send ^c
-    ClipWait
+    ClipWait, 0
+	if ErrorLevel
+	{
+		return
+	}
     itemInfo := clipboard
     clipboard := ""
 


### PR DESCRIPTION
Not mouseovering over a station would have the timeout going indefinetely.